### PR TITLE
Settings revamp

### DIFF
--- a/OmniConverter/Extensions/MIDI/MIDIAnalysis.cs
+++ b/OmniConverter/Extensions/MIDI/MIDIAnalysis.cs
@@ -40,7 +40,7 @@ namespace OmniConverter
             _cancToken = new CancellationTokenSource();
             _parallelOptions = new ParallelOptions
             {
-                MaxDegreeOfParallelism = Program.Settings.MultiThreadedMode ? threads.LimitToRange(1, Environment.ProcessorCount) : 1,
+                MaxDegreeOfParallelism = Program.Settings.Render.MultiThreadedMode ? threads.LimitToRange(1, Environment.ProcessorCount) : 1,
                 CancellationToken = _cancToken.Token
             };
         }

--- a/OmniConverter/Extensions/MiscFunctions.cs
+++ b/OmniConverter/Extensions/MiscFunctions.cs
@@ -69,15 +69,15 @@ namespace OmniConverter
             switch (selectedSound)
             {
                 case ConvSounds.Finish:
-                    sound = Program.Settings.OldKMCScheme ? "convfinold.wav" : "convfin.wav";
+                    sound = Program.Settings.Program.OldKMCScheme ? "convfinold.wav" : "convfin.wav";
                     break;
 
                 case ConvSounds.Error:
-                    sound = Program.Settings.OldKMCScheme ? "convfailold.wav" : "convfail.wav";
+                    sound = Program.Settings.Program.OldKMCScheme ? "convfailold.wav" : "convfail.wav";
                     break;
 
                 case ConvSounds.Start:
-                    sound = Program.Settings.OldKMCScheme ? "convstartold.wav" : "convstart.wav";
+                    sound = Program.Settings.Program.OldKMCScheme ? "convstartold.wav" : "convstart.wav";
                     break;
 
                 default:
@@ -110,7 +110,7 @@ namespace OmniConverter
 
         public static void PerformShutdownCheck(Stopwatch stopwatch)
         {
-            var action = Program.Settings.AfterRenderAction;
+            var action = Program.Settings.Program.AfterRenderAction;
 
             // Currently only under Windows, sorry!
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && action < 4)

--- a/OmniConverter/Extensions/Settings.cs
+++ b/OmniConverter/Extensions/Settings.cs
@@ -4,14 +4,211 @@ using System.Collections.ObjectModel;
 
 namespace OmniConverter
 {
-    public enum SincInterType
+    [JsonObject]
+    public class GlobalSynthSettings : ICloneable
     {
-        Linear = 0,
-        Point8,
-        Point16,
-        Point32,
-        Point64,
-        Max = Point64
+        public enum InterpolationType
+        {
+            None = 0,
+            Linear,
+            Point8,
+            Point16,
+            Point32,
+            Point64,
+            Max = Point64
+        }
+
+        [JsonProperty]
+        public double Volume = 1.0;
+
+        [JsonProperty]
+        public int SampleRate = 48000;
+
+        [JsonProperty]
+        public InterpolationType Interpolation = InterpolationType.Point16;
+
+        [JsonProperty]
+        public bool KilledNoteFading = false;
+
+        [JsonProperty]
+        public bool AudioLimiter = false;
+
+        [JsonProperty]
+        public bool RTSMode = false;
+
+        [JsonProperty]
+        public double RTSFPS = 90.0;
+
+        [JsonProperty]
+        public double RTSFluct = 75.0;
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+    }
+
+    [JsonObject]
+    public class BASSSettings : ICloneable
+    {
+        [JsonProperty]
+        public int MaxVoices = 2048;
+
+        [JsonProperty]
+        public bool DisableEffects = true;
+
+        [JsonProperty]
+        public bool NoteOff1 = false;
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+    }
+
+    [JsonObject]
+    public class XSynthSettings : ICloneable
+    {
+        public enum ThreadingType
+        {
+            None = 0,
+            PerChannel,
+            PerKey,
+            Max = PerKey,
+        }
+
+        [JsonProperty]
+        public ulong MaxLayers = 32;
+
+        [JsonProperty]
+        public bool UseEffects = true;
+
+        [JsonProperty]
+        public ThreadingType Threading = ThreadingType.PerKey;
+
+        [JsonProperty]
+        public bool LinearEnvelope = false;
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+    }
+
+    [JsonObject]
+    public class EncoderSettings : ICloneable
+    {
+        [JsonProperty]
+        public AudioCodecType AudioCodec = AudioCodecType.PCM;
+
+        [JsonProperty]
+        public int AudioBitrate = 256; // kbps
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+    }
+
+    [JsonObject]
+    public class EventSettings : ICloneable
+    {
+        [JsonProperty]
+        public bool FilterVelocity = false;
+
+        [JsonProperty]
+        public int VelocityLow = 1;
+
+        [JsonProperty]
+        public int VelocityHigh = 1;
+
+        [JsonProperty]
+        public bool FilterKey = false;
+
+        [JsonProperty]
+        public int KeyLow = 0;
+
+        [JsonProperty]
+        public int KeyHigh = 127;
+
+        [JsonProperty]
+        public bool OverrideEffects = false;
+
+        [JsonProperty]
+        public short ReverbVal = 64;
+
+        [JsonProperty]
+        public short ChorusVal = 64;
+
+        [JsonProperty]
+        public bool IgnoreProgramChanges = false;
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+    }
+
+     [JsonObject]
+    public class RenderSettings : ICloneable
+    {
+        // Threads count is set to ProcessorCount / 2 ,
+        // to avoid having the converter hog up all the resources
+        [JsonProperty]
+        public bool MultiThreadedMode = true;
+
+        [JsonProperty]
+        public int ThreadsCount = Environment.ProcessorCount / 2;
+
+        [JsonProperty]
+        public bool PerTrackMode = false;
+
+        [JsonProperty]
+        public bool PerTrackFile = false;
+
+        [JsonProperty]
+        public bool PerTrackStorage = false;
+
+        [JsonProperty]
+        public bool AutoExportToFolder = false;
+
+        [JsonProperty]
+        public string AutoExportFolderPath = string.Empty;
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+    }
+
+    [JsonObject]
+    public class ProgramSettings : ICloneable
+    {
+        [JsonProperty]
+        public bool AutoSaveState = false;
+
+        [JsonProperty]
+        public bool RichPresence = true;
+
+        [JsonProperty]
+        public bool AutoUpdateCheck = false;
+
+        [JsonProperty]
+        public UpdateSystem.Branch UpdateBranch = UpdateSystem.Branch.None;
+
+        [JsonProperty]
+        public int AfterRenderAction = -1;
+
+        [JsonProperty]
+        public bool AudioEvents = true;
+
+        [JsonProperty]
+        public bool OldKMCScheme = false;
+
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
     }
 
     public class Settings : ICloneable
@@ -20,101 +217,37 @@ namespace OmniConverter
         public EngineID Renderer = EngineID.BASS;
 
         [JsonProperty]
-        public double Volume = 1.0;
-        [JsonProperty]
-        public int SampleRate = 48000;
-        [JsonProperty]
-        public AudioCodecType AudioCodec = AudioCodecType.PCM;
-        [JsonProperty]
-        public int AudioBitrate = 256; // kbps
+        public GlobalSynthSettings Synth = new();
 
         [JsonProperty]
-        public int MaxVoices = 2000;
-        [JsonProperty]
-        public ulong MaxLayers = 2;
-        [JsonProperty]
-        public bool DisableEffects = true;
-        [JsonProperty]
-        public bool AudioLimiter = false;
-        [JsonProperty]
-        public bool KilledNoteFading = false;
+        public BASSSettings BASS = new();
 
         [JsonProperty]
-        public bool FilterVelocity = false;
-        [JsonProperty]
-        public int VelocityLow = 1;
-        [JsonProperty]
-        public int VelocityHigh = 1;
-        [JsonProperty]
-        public bool FilterKey = false;
-        [JsonProperty]
-        public int KeyLow = 0;
-        [JsonProperty]
-        public int KeyHigh = 127;
-        [JsonProperty]
-        public bool OverrideEffects = false;
-        [JsonProperty]
-        public short ReverbVal = 64;
-        [JsonProperty]
-        public short ChorusVal = 64;
-        [JsonProperty]
-        public bool IgnoreProgramChanges = false;
-
-        // Threads count is set to ProcessorCount / 2 ,
-        // to avoid having the converter hog up all the resources
-        [JsonProperty]
-        public bool MultiThreadedMode = true;
-        [JsonProperty]
-        public bool AutoSaveState = false;
-        [JsonProperty]
-        public int ThreadsCount = Environment.ProcessorCount / 2;
-        [JsonProperty]
-        public bool PerTrackMode = false;
-        [JsonProperty]
-        public bool PerTrackFile = false;
-        [JsonProperty]
-        public bool PerTrackStorage = false;
+        public XSynthSettings XSynth = new();
 
         [JsonProperty]
-        public bool NoteOff1 = false;
-        [JsonProperty]
-        public SincInterType SincInter = SincInterType.Point16;
+        public EncoderSettings Encoder = new();
 
         [JsonProperty]
-        public bool RichPresence = true;
+        public EventSettings Event = new();
 
         [JsonProperty]
-        public bool RTSMode = false;
-        [JsonProperty]
-        public double RTSFPS = 90.0;
-        [JsonProperty]
-        public double RTSFluct = 75.0;
+        public RenderSettings Render = new();
 
         [JsonProperty]
-        public bool AutoUpdateCheck = false;
-        [JsonProperty]
-        public UpdateSystem.Branch UpdateBranch = UpdateSystem.Branch.None;
-
-        [JsonProperty]
-        public bool AutoExportToFolder = false;
-        [JsonProperty]
-        public string AutoExportFolderPath = string.Empty;
-        [JsonProperty]
-        public int AfterRenderAction = -1;
-        [JsonProperty]
-        public bool AudioEvents = true;
-        [JsonProperty]
-        public bool OldKMCScheme = false;
+        public ProgramSettings Program = new();
 
         [JsonProperty]
         public string LastMIDIFolder = string.Empty;
+
         [JsonProperty]
         public string LastSoundFontFolder = string.Empty;
+        
         [JsonProperty]
         public string LastExportFolder = string.Empty;
 
         [JsonProperty("SoundFonts")]
-        public ObservableCollection<SoundFont> SoundFontsList = new();
+        public ObservableCollection<SoundFont> SoundFontsList = [];
 
         public object Clone()
         {

--- a/OmniConverter/Extensions/UpdateSystem/ChangeBranch.axaml.cs
+++ b/OmniConverter/Extensions/UpdateSystem/ChangeBranch.axaml.cs
@@ -12,7 +12,7 @@ public partial class ChangeBranch : Window
     {
         InitializeComponent();
 
-        SelectedBranch.SelectedIndex = ((int)Program.Settings.UpdateBranch).LimitToRange((int)UpdateSystem.Branch.None, (int)UpdateSystem.Branch.Total);
+        SelectedBranch.SelectedIndex = ((int)Program.Settings.Program.UpdateBranch).LimitToRange((int)UpdateSystem.Branch.None, (int)UpdateSystem.Branch.Total);
 
         SolidColorBrush brchCol = new SolidColorBrush();
         brchCol.Color = UpdateSystem.GetCurrentBranchColor();
@@ -22,7 +22,7 @@ public partial class ChangeBranch : Window
 
     private void ConfirmBranchChange(object? sender, RoutedEventArgs e)
     {
-        Program.Settings.UpdateBranch = (UpdateSystem.Branch)SelectedBranch.SelectedIndex;
+        Program.Settings.Program.UpdateBranch = (UpdateSystem.Branch)SelectedBranch.SelectedIndex;
         Program.SaveConfig();
         Close();
     }

--- a/OmniConverter/Extensions/UpdateSystem/UpdateSystem.cs
+++ b/OmniConverter/Extensions/UpdateSystem/UpdateSystem.cs
@@ -124,7 +124,7 @@ namespace OmniConverter
 
         public static string GetCurrentBranch()
         {
-            return Program.Settings.UpdateBranch switch
+            return Program.Settings.Program.UpdateBranch switch
             {
                 Branch.Canary => "Canary branch",
                 Branch.Release => "Release branch",
@@ -135,7 +135,7 @@ namespace OmniConverter
 
         public static Color GetCurrentBranchColor()
         {
-            return Program.Settings.UpdateBranch switch
+            return Program.Settings.Program.UpdateBranch switch
             {
                 Branch.Canary => Color.FromRgb(221, 172, 5),
                 Branch.Release => Color.FromRgb(158, 14, 204),
@@ -146,7 +146,7 @@ namespace OmniConverter
 
         public static string GetCurrentBranchToolTip()
         {
-            return Program.Settings.UpdateBranch switch
+            return Program.Settings.Program.UpdateBranch switch
             {
                 Branch.Canary => "Receive all updates.\nYou may get broken updates that haven't been fully tested.\nDesigned for testers and early adopters.",
                 Branch.Release => "Receive occasional updates and urgent bugfixes (Eg. from version x.0.x.x to x.1.x.x).\nRecommended.",
@@ -174,7 +174,7 @@ namespace OmniConverter
 
                     if (convCurrent != null && convOnline != null)
                     {
-                        switch (Program.Settings.UpdateBranch)
+                        switch (Program.Settings.Program.UpdateBranch)
                         {
                             case Branch.Canary:
                                 if (convCurrent.Major < convOnline.Major || convCurrent.Minor < convOnline.Minor)

--- a/OmniConverter/Extensions/UpdateSystem/UpdateSystem.cs
+++ b/OmniConverter/Extensions/UpdateSystem/UpdateSystem.cs
@@ -13,7 +13,7 @@ namespace OmniConverter
         public static GitHubClient UpdateClient = new GitHubClient(new ProductHeaderValue(ProductName));
 
         public const string ProductName = "OmniConverter";
-        public const string GitHubPage = $"https://github.com/KaleidonKep99/{ProductName}";
+        public const string GitHubPage = $"https://github.com/BlackMIDIDevs/{ProductName}";
         public const string SetupFile = $"{GitHubPage}/releases/download/{{0}}/OmniConverterSetup.exe";
         public const string UpdatePage = $"{GitHubPage}/releases/tag/{{0}}";
 
@@ -112,7 +112,7 @@ namespace OmniConverter
             {
                 try
                 {
-                    Octokit.Release Release = UpdateClient.Repository.Release.GetLatest("KaleidonKep99", "OmniConverter").Result;
+                    Octokit.Release Release = UpdateClient.Repository.Release.GetLatest("BlackMIDIDevs", "OmniConverter").Result;
                     Process.Start(String.Format(UpdatePage, Release.TagName));
                 }
                 catch (Exception ex)
@@ -166,7 +166,7 @@ namespace OmniConverter
             {
                 try
                 {
-                    Release Release = UpdateClient.Repository.Release.GetAll("KaleidonKep99", "OmniConverter").Result[0];
+                    Release Release = UpdateClient.Repository.Release.GetAll("BlackMIDIDevs", "OmniConverter").Result[0];
 
                     Version? convOnline = null;
                     Version.TryParse(Release.TagName, out convOnline);

--- a/OmniConverter/Forms/InfoWindow.axaml.cs
+++ b/OmniConverter/Forms/InfoWindow.axaml.cs
@@ -46,12 +46,12 @@ public partial class InfoWindow : Window
 
     private void GitHubPage(object? sender, PointerPressedEventArgs e)
     {
-        Process.Start(new ProcessStartInfo("https://github.com/KaleidonKep99/OmniConverter") { UseShellExecute = true });
+        Process.Start(new ProcessStartInfo("https://github.com/BlackMIDIDevs/OmniConverter") { UseShellExecute = true });
     }
 
     private void LicensePage(object? sender, PointerPressedEventArgs e)
     {
-        Process.Start(new ProcessStartInfo("https://github.com/KaleidonKep99/OmniConverter/blob/master/LICENSE.md") { UseShellExecute = true });
+        Process.Start(new ProcessStartInfo("https://github.com/BlackMIDIDevs/OmniConverter/blob/master/LICENSE.md") { UseShellExecute = true });
     }
 
     private async void ChangeBranch(object? sender, RoutedEventArgs e)

--- a/OmniConverter/Forms/MIDIWindow.axaml.cs
+++ b/OmniConverter/Forms/MIDIWindow.axaml.cs
@@ -55,7 +55,7 @@ public partial class MIDIWindow : Window
             Title = "MIDI analysis";
             TogglePause.IsVisible = false;
             ControlBar.ColumnDefinitions = new("8*, 0, 140");
-            _worker = new MIDIAnalysis(_files, _silent, Program.Settings.MultiThreadedMode ? Program.Settings.ThreadsCount : 1, this, LogArea, _winRef.MIDIs);
+            _worker = new MIDIAnalysis(_files, _silent, Program.Settings.Render.MultiThreadedMode ? Program.Settings.Render.ThreadsCount : 1, this, LogArea, _winRef.MIDIs);
         }
         else
         {
@@ -76,7 +76,7 @@ public partial class MIDIWindow : Window
                 ControlBar.ColumnDefinitions = new("8*, 96, 96");
                 string outputFolder = string.Empty;
 
-                if (!Program.Settings.AutoExportToFolder)
+                if (!Program.Settings.Render.AutoExportToFolder)
                 {
                     var topLevel = GetTopLevel(this);
 
@@ -104,10 +104,10 @@ public partial class MIDIWindow : Window
                         }
                     }
                 }
-                else outputFolder = Program.Settings.AutoExportFolderPath;
+                else outputFolder = Program.Settings.Render.AutoExportFolderPath;
 
                 if (!string.IsNullOrEmpty(outputFolder))
-                    _worker = new MIDIConverter(outputFolder, Program.Settings.AudioCodec, Program.Settings.MultiThreadedMode ? Program.Settings.ThreadsCount : 1, this, LogArea, _winRef.MIDIs);
+                    _worker = new MIDIConverter(outputFolder, Program.Settings.Encoder.AudioCodec, Program.Settings.Render.MultiThreadedMode ? Program.Settings.Render.ThreadsCount : 1, this, LogArea, _winRef.MIDIs);
             }
             else MessageBox.Show(this, "There are no MIDIs to convert.", "OmniConverter - Information");
         }
@@ -177,7 +177,7 @@ public partial class MIDIWindow : Window
         return;
 
         // Not yet
-        if (Program.Settings.AutoSaveState && _convBackup.Elapsed.TotalSeconds >= 3 && _worker is MIDIConverter)
+        if (Program.Settings.Program.AutoSaveState && _convBackup.Elapsed.TotalSeconds >= 3 && _worker is MIDIConverter)
         {
             _convBackup.Restart();
 

--- a/OmniConverter/Forms/MainWindow.axaml.cs
+++ b/OmniConverter/Forms/MainWindow.axaml.cs
@@ -29,13 +29,13 @@ namespace OmniConverter
             _volumeWatcher.Interval = TimeSpan.FromSeconds(1);
             _volumeWatcher.Tick += VolumeWatcherFunc;
 
-            OutputVolumeSlider.Value = Program.Settings.Volume;
+            OutputVolumeSlider.Value = Program.Settings.Synth.Volume;
 
             AddHandler(DragDrop.DropEvent, FileDropInit);
             AddHandler(DragDrop.DragEnterEvent, FileDropEnter);
             // AddHandler(DragDrop.DragLeaveEvent, FileDropLeave);
 
-            if (Program.Settings.AutoUpdateCheck)
+            if (Program.Settings.Program.AutoUpdateCheck)
                 UpdateSystem.CheckForUpdates(false, true);
 
 #if !DEBUG
@@ -64,7 +64,7 @@ namespace OmniConverter
 
         private void CheckBranch(object? sender, RoutedEventArgs e)
         {
-            if (Program.Settings.UpdateBranch == UpdateSystem.Branch.None)
+            if (Program.Settings.Program.UpdateBranch == UpdateSystem.Branch.None)
                 new ChangeBranch().ShowDialog(this);
         }
 
@@ -266,7 +266,7 @@ namespace OmniConverter
 
         private void VolumeWatcherFunc(object? sender, EventArgs e)
         {
-            Program.Settings.Volume = OutputVolumeSlider.Value;
+            Program.Settings.Synth.Volume = OutputVolumeSlider.Value;
             Program.SaveConfig();
             _volumeWatcher.Stop();
         }

--- a/OmniConverter/Forms/SettingsWindow.axaml
+++ b/OmniConverter/Forms/SettingsWindow.axaml
@@ -15,75 +15,85 @@
 		RequestedThemeVariant="Dark">
 	<Grid RowDefinitions="1*, 80">
 		<TabControl Grid.Row="0">
-			<TabItem Header="Audio renderer">
+			<TabItem Header="Synthesizer">
 				<ScrollViewer VerticalScrollBarVisibility="Visible">
 					<StackPanel Margin="4">
 						<Grid Name="RendererPanel" Margin="2"  ColumnDefinitions="2*, 1*">
-							<Label Grid.Column="0" Content="Audio renderer" VerticalAlignment="Center"/>
+							<Label Grid.Column="0" Content="Synthesizer" VerticalAlignment="Center"/>
 							<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1">
-								<Image Name="NotDesignedForThis" Width="24" Source="/Assets/Warning.png" Margin="0, 0, 4, 0" IsVisible="False" PointerPressed="NotDesignedForThisWarning" />
 								<ComboBox Name="SelectedRenderer" Width="180" SelectedIndex="0" MaxDropDownHeight="200" SelectionChanged="AudioRendererChanged" >
-									<ComboBoxItem Name="BASS">BASS</ComboBoxItem>
-									<ComboBoxItem Name="XSynth">XSynth</ComboBoxItem>
+									<ComboBoxItem>BASS</ComboBoxItem>
+									<ComboBoxItem>XSynth</ComboBoxItem>
 								</ComboBox>
 							</StackPanel>
 						</Grid>
-						<Grid ColumnDefinitions="1*, 2*" Margin="2">
-							<Label Name="MaxVoicesLabel" Grid.Column="0" Content="Voice limit" VerticalAlignment="Center"/>
-							<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1" >
-								<CheckBox Name="NoVoiceLimit" Content="Uncap limit" Margin="0, 0, 10, 0" IsCheckedChanged="KhangModCheck"/>
-								<NumericUpDown Name="MaxVoices" HorizontalAlignment="Right" Width="180" FormatString="0" Value="100000" Minimum="1" Maximum="100000" ValueChanged="MaxVoicesChanged" />
+						<ctrl:GroupBox Header="Global Settings" Theme="{StaticResource GroupBoxClassic}" Margin="0, 16, 0, 0" >
+							<StackPanel>
+								<Grid ColumnDefinitions="4*, 1*" Margin="2">
+									<Label Grid.Column="0" Content="Sample rate" VerticalAlignment="Center"/>
+									<ComboBox Name="SampleRate" HorizontalAlignment="Right" Grid.Column="1" Width="180" SelectedIndex="5" MaxDropDownHeight="200">
+										<ComboBoxItem>384000</ComboBoxItem>
+										<ComboBoxItem>192000</ComboBoxItem>
+										<ComboBoxItem>96000</ComboBoxItem>
+										<ComboBoxItem>88200</ComboBoxItem>
+										<ComboBoxItem>64000</ComboBoxItem>
+										<ComboBoxItem>48000</ComboBoxItem>
+										<ComboBoxItem>44100</ComboBoxItem>
+										<ComboBoxItem>32000</ComboBoxItem>
+										<ComboBoxItem>22050</ComboBoxItem>
+										<ComboBoxItem>11025</ComboBoxItem>
+										<ComboBoxItem>8000</ComboBoxItem>
+										<ComboBoxItem>4000</ComboBoxItem>
+									</ComboBox>
+								</Grid>
+								<Grid Name="InterpolationPanel" Margin="2" ColumnDefinitions="2*, 1*">
+									<Label Content="Interpolation mode" VerticalAlignment="Center"/>
+									<ComboBox Name="InterpolationSelection" HorizontalAlignment="Right" Grid.Column="1" Width="180" SelectedIndex="0" MaxDropDownHeight="200" >
+										<ComboBoxItem>None</ComboBoxItem>
+										<ComboBoxItem>Linear inter.</ComboBoxItem>
+										<ComboBoxItem>8 point sinc inter.</ComboBoxItem>
+										<ComboBoxItem>16 point sinc inter.</ComboBoxItem>
+										<ComboBoxItem>32 point sinc inter.</ComboBoxItem>
+										<ComboBoxItem>64 point sinc inter.</ComboBoxItem>
+									</ComboBox>
+								</Grid>
+								<CheckBox Name="KilledNoteFading" Content="Disable sample fade out when killing a note" Margin="2" />
 							</StackPanel>
-						</Grid>
-						<Grid ColumnDefinitions="4*, 1*" Margin="2">
-							<Label Grid.Column="0" Content="Sample rate" VerticalAlignment="Center"/>
-							<ComboBox Name="SampleRate" HorizontalAlignment="Right" Grid.Column="1" Width="180" SelectedIndex="5" MaxDropDownHeight="200">
-								<ComboBoxItem>384000</ComboBoxItem>
-								<ComboBoxItem>192000</ComboBoxItem>
-								<ComboBoxItem>96000</ComboBoxItem>
-								<ComboBoxItem>88200</ComboBoxItem>
-								<ComboBoxItem>64000</ComboBoxItem>
-								<ComboBoxItem>48000</ComboBoxItem>
-								<ComboBoxItem>44100</ComboBoxItem>
-								<ComboBoxItem>32000</ComboBoxItem>
-								<ComboBoxItem>22050</ComboBoxItem>
-								<ComboBoxItem>11025</ComboBoxItem>
-								<ComboBoxItem>8000</ComboBoxItem>
-								<ComboBoxItem>4000</ComboBoxItem>
-							</ComboBox>
-						</Grid>
-						<Grid Name="SincInterPanel" Margin="2" ColumnDefinitions="2*, 1*">
-							<Label Content="Sinc interpolation mode" VerticalAlignment="Center"/>
-							<ComboBox Name="SincInterSelection" HorizontalAlignment="Right" Grid.Column="1" Width="180" SelectedIndex="0" MaxDropDownHeight="200" >
-								<ComboBoxItem>Linear inter. (OFF)</ComboBoxItem>
-								<ComboBoxItem>8 point sinc inter.</ComboBoxItem>
-								<ComboBoxItem>16 point sinc inter.</ComboBoxItem>
-								<ComboBoxItem>32 point sinc inter.</ComboBoxItem>
-								<ComboBoxItem>64 point sinc inter.</ComboBoxItem>
-							</ComboBox>
-						</Grid>
-						<Grid Name="AudioCodecPanel" Margin="2, 16, 0, 0"  ColumnDefinitions="2*, 1*">
-							<Label Grid.Column="0" Content="Audio codec" VerticalAlignment="Center"/>
-							<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1">
-								<Image Name="NoFFMPEG" Width="24" Source="/Assets/Warning.png" Margin="0, 0, 4, 0" IsVisible="False" PointerPressed="NoFFMPEGWarning" />
-								<ComboBox Name="AudioCodec" Width="180" SelectedIndex="0" MaxDropDownHeight="200" SelectionChanged="AudioCodecChanged" >
-									<ComboBoxItem Name="WAV">.wav (IEEE, lossless)</ComboBoxItem>
-									<ComboBoxItem Name="FLAC">.flac (FLAC, lossless)</ComboBoxItem>
-									<ComboBoxItem Name="MP3">.mp3 (LAME, lossy)</ComboBoxItem>
-									<ComboBoxItem Name="OGG">.ogg (Vorbis, lossy)</ComboBoxItem>
-								</ComboBox>
+						</ctrl:GroupBox>
+						<ctrl:GroupBox Name="BASSSettingsPanel" Header="BASS Settings" Theme="{StaticResource GroupBoxClassic}" Margin="0, 16, 0, 0" >
+							<StackPanel>
+								<Grid ColumnDefinitions="1*, 2*" Margin="2">
+									<Label Grid.Column="0" Content="Voice limit" VerticalAlignment="Center"/>
+									<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1" >
+										<CheckBox Name="BASS_NoVoiceLimit" Content="Uncap limit" Margin="0, 0, 10, 0" IsCheckedChanged="KhangModCheck"/>
+										<NumericUpDown Name="BASS_MaxVoices" HorizontalAlignment="Right" Width="180" FormatString="0" Value="100000" Minimum="1" Maximum="100000" ValueChanged="MaxVoicesChanged" />
+									</StackPanel>
+								</Grid>
+								<CheckBox Name="BASS_DisableFX" Content="Disable sound FXs (Reverb, Chorus etc.)" Margin="2" />
+								<CheckBox Name="BASS_NoteOff1" Content="Follow overlaps when processing note off events" Margin="2" />
 							</StackPanel>
-						</Grid>
-						<Grid Name="AudioBitratePanel" Margin="2" ColumnDefinitions="2*, 1*">
-							<Label Grid.Column="0" Content="Audio bitrate (kbps)" VerticalAlignment="Center"/>
-							<StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
-								<NumericUpDown Name="AudioBitrate" HorizontalAlignment="Right" Width="180" Value="256" Minimum="0" Maximum="1000" FormatString="0" IsEnabled="False"/>
+						</ctrl:GroupBox>
+						<ctrl:GroupBox Name="XSynthSettingsPanel" Header="XSynth Settings" Theme="{StaticResource GroupBoxClassic}" Margin="0, 16, 0, 0" >
+							<StackPanel>
+								<Grid ColumnDefinitions="1*, 2*" Margin="2">
+									<Label Grid.Column="0" Content="Layer limit" VerticalAlignment="Center"/>
+									<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1" >
+										<CheckBox Name="XSynth_NoLayerLimit" Content="Unlimited" Margin="0, 0, 10, 0" IsCheckedChanged="UnlimitedLayersCheck"/>
+										<NumericUpDown Name="XSynth_MaxLayers" HorizontalAlignment="Right" Width="180" FormatString="0" Value="32" Minimum="1" Maximum="10000000" />
+									</StackPanel>
+								</Grid>
+								<Grid Margin="2" ColumnDefinitions="2*, 1*">
+									<Label Content="Multithreading mode" VerticalAlignment="Center"/>
+									<ComboBox Name="XSynth_ThreadingSelection" HorizontalAlignment="Right" Grid.Column="1" Width="180" SelectedIndex="2" MaxDropDownHeight="200" >
+										<ComboBoxItem>None</ComboBoxItem>
+										<ComboBoxItem>Per channel</ComboBoxItem>
+										<ComboBoxItem>Per key</ComboBoxItem>
+									</ComboBox>
+								</Grid>
+								<CheckBox Name="XSynth_UseEffects" Content="Use sound effects (Cutoff etc.)" Margin="2" />
+								<CheckBox Name="XSynth_LinearEnv" Content="Use linear decay and release phases in volume envelopes" Margin="2" />
 							</StackPanel>
-						</Grid>
-						<CheckBox Name="DisableFX" Content="Disable sound FXs (Reverb, Chorus etc.)" Margin="2, 16, 0, 0" />
-						<CheckBox Name="NoteOff1" Content="Follow overlaps when processing note off events" Margin="2" />
-						<CheckBox Name="KilledNoteFading" Content="Disable sample fade out when killing a note" Margin="2" />
-						<CheckBox Name="AudioLimiter" Content="Enable audio limiter, to prevent distortion" Margin="2" />
+						</ctrl:GroupBox>
 						<ctrl:GroupBox Header="Real Time Playback Simulation" Theme="{StaticResource GroupBoxClassic}" Margin="0, 16, 0, 0" >
 							<Grid ColumnDefinitions="1*, 1*" >
 								<CheckBox Name="RTSMode" Grid.Column="0" Content="Enable real time playback simulation" IsCheckedChanged="RTSModeCheck" />
@@ -135,32 +145,69 @@
 				</StackPanel>
 			</TabItem>
 			<TabItem Header="Export">
-				<StackPanel Margin="4">
-					<CheckBox Name="MTMode" Content="Enable multi-threaded rendering mode, and render one MIDI (or MIDI track) per thread" Margin="2" IsCheckedChanged="MTModeCheck" />
-					<CheckBox Name="NoLimitThreadsOnCPU" Content="Allow allocation of more threads than what's available on the processor" Margin="2" IsCheckedChanged="NoLimitThreadsOnCPUCheck" />
-					<Grid Name="LimitThreadsPanel" ColumnDefinitions="2*, 1*" Margin="2" >
-						<CheckBox Name="LimitThreads" Content="Limit the amount of system threads available to the app" Grid.Column="0" IsCheckedChanged="LimitThreadsCheck" />
-						<StackPanel Name="MaxThreadsPanel" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" >
-							<Label Content="Threads" VerticalAlignment="Center"/>
-							<NumericUpDown Name="MaxThreads" HorizontalAlignment="Right" Width="160" FormatString="0" Minimum="1" Maximum="65536" />
-						</StackPanel>
-					</Grid>
-					<CheckBox Name="PerTrackMode" Content="Render each track separately, then merge all of them in one audio file" Margin="2, 16, 0, 0" IsCheckedChanged="PerTrackModeCheck" />
-					<CheckBox Name="PerTrackFile" IsEnabled="False" Content="Disable automatic merging of the tracks, and export all in separate files" Margin="2" IsCheckedChanged="PerTrackFileCheck"  />
-					<CheckBox Name="PerTrackStorage" IsEnabled="False" Content="Store each exported track into a folder with the same name as the MIDI" Margin="2" />
-					<CheckBox Name="AutoExportToFolder" Content="Do not ask for an export folder, and export renders directly to this folder:" Margin="2, 16, 0, 0" IsCheckedChanged="AutoExportFolderCheck" />
-					<Grid Name="AutoExportFolderPanel" ColumnDefinitions="1*, 96" Margin="2" >
-						<TextBox Name="AutoExportFolderPath" Grid.Column="0" Margin="0, 0, 10, 0" />
-						<Button Content="Browse" HorizontalContentAlignment="Center" Grid.Column="1" Width="96" Click="AutoExportFolderSelection"/>
-					</Grid>
-					<CheckBox Name="AfterRenderAction" Content="Do one of the following actions once the computer is done rendering" Margin="2, 16, 0, 0" IsCheckedChanged="AfterRenderActionCheck"/>
+				<ScrollViewer VerticalScrollBarVisibility="Visible">
+				<StackPanel>
+				<ctrl:GroupBox Header="Multithreading" Theme="{StaticResource GroupBoxClassic}" Margin="0, 16, 0, 0" >
+					<StackPanel>
+						<CheckBox Name="MTMode" Content="Enable multi-threaded rendering mode, and render one MIDI (or MIDI track) per thread" Margin="2" IsCheckedChanged="MTModeCheck" />
+						<CheckBox Name="NoLimitThreadsOnCPU" Content="Allow allocation of more threads than what's available on the processor" Margin="2" IsCheckedChanged="NoLimitThreadsOnCPUCheck" />
+						<Grid Name="LimitThreadsPanel" ColumnDefinitions="2*, 1*" Margin="2" >
+							<CheckBox Name="LimitThreads" Content="Limit the amount of system threads available to the app" Grid.Column="0" IsCheckedChanged="LimitThreadsCheck" />
+							<StackPanel Name="MaxThreadsPanel" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" >
+								<Label Content="Threads" VerticalAlignment="Center"/>
+								<NumericUpDown Name="MaxThreads" HorizontalAlignment="Right" Width="160" FormatString="0" Minimum="1" Maximum="65536" />
+							</StackPanel>
+						</Grid>
+					</StackPanel>
+				</ctrl:GroupBox>
+				<ctrl:GroupBox Header="Render settings" Theme="{StaticResource GroupBoxClassic}" Margin="0, 16, 0, 0" >
+					<StackPanel>
+						<CheckBox Name="PerTrackMode" Content="Render each track separately, then merge all of them in one audio file" Margin="2" IsCheckedChanged="PerTrackModeCheck" />
+						<CheckBox Name="PerTrackFile" IsEnabled="False" Content="Disable automatic merging of the tracks, and export all in separate files" Margin="2" IsCheckedChanged="PerTrackFileCheck"  />
+						<CheckBox Name="PerTrackStorage" IsEnabled="False" Content="Store each exported track into a folder with the same name as the MIDI" Margin="2" />
+						<CheckBox Name="AutoExportToFolder" Content="Do not ask for an export folder, and export renders directly to this folder:" Margin="2, 16, 0, 0" IsCheckedChanged="AutoExportFolderCheck" />
+						<Grid Name="AutoExportFolderPanel" ColumnDefinitions="1*, 96" Margin="2" >
+							<TextBox Name="AutoExportFolderPath" Grid.Column="0" Margin="0, 0, 10, 0" />
+							<Button Content="Browse" HorizontalContentAlignment="Center" Grid.Column="1" Width="96" Click="AutoExportFolderSelection"/>
+						</Grid>
+					</StackPanel>
+				</ctrl:GroupBox>
+				<ctrl:GroupBox Header="Audio encoding" Theme="{StaticResource GroupBoxClassic}" Margin="0, 16, 0, 0" >
+					<StackPanel>
+						<CheckBox Name="AudioLimiter" Content="Enable audio limiter, to prevent distortion" Margin="2" />
+						<Grid Name="AudioCodecPanel" Margin="2"  ColumnDefinitions="2*, 1*">
+							<Label Grid.Column="0" Content="Audio codec" VerticalAlignment="Center"/>
+							<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1">
+								<Image Name="NoFFMPEG" Width="24" Source="/Assets/Warning.png" Margin="0, 0, 4, 0" IsVisible="False" PointerPressed="NoFFMPEGWarning" />
+								<ComboBox Name="AudioCodec" Width="180" SelectedIndex="0" MaxDropDownHeight="200" SelectionChanged="AudioCodecChanged" >
+									<ComboBoxItem Name="WAV">.wav (IEEE, lossless)</ComboBoxItem>
+									<ComboBoxItem Name="FLAC">.flac (FLAC, lossless)</ComboBoxItem>
+									<ComboBoxItem Name="MP3">.mp3 (LAME, lossy)</ComboBoxItem>
+									<ComboBoxItem Name="OGG">.ogg (Vorbis, lossy)</ComboBoxItem>
+								</ComboBox>
+							</StackPanel>
+						</Grid>
+						<Grid Name="AudioBitratePanel" Margin="2" ColumnDefinitions="2*, 1*">
+							<Label Grid.Column="0" Content="Audio bitrate (kbps)" VerticalAlignment="Center"/>
+							<StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+								<NumericUpDown Name="AudioBitrate" HorizontalAlignment="Right" Width="180" Value="256" Minimum="0" Maximum="1000" FormatString="0" IsEnabled="False"/>
+							</StackPanel>
+						</Grid>
+					</StackPanel>
+				</ctrl:GroupBox>
+				</StackPanel>
+				</ScrollViewer>
+			</TabItem>
+			<TabItem Header="General">
+				<StackPanel>
+					<CheckBox Name="AfterRenderAction" Content="Do one of the following actions once the computer is done rendering" Margin="2" IsCheckedChanged="AfterRenderActionCheck"/>
 					<ComboBox Name="AfterRenderSelectedAction" Width="320" SelectedIndex="1" MaxDropDownHeight="200" Margin="2" IsEnabled="False">
 						<ComboBoxItem>Put the computer into sleep mode</ComboBoxItem>
 						<ComboBoxItem>Put the computer into hibernation mode</ComboBoxItem>
 						<ComboBoxItem>Turn the computer off</ComboBoxItem>
 						<ComboBoxItem>Restart the computer</ComboBoxItem>
-                        <ComboBoxItem>Close the application</ComboBoxItem>
-                        <ComboBoxItem>Show completion time</ComboBoxItem>
+						<ComboBoxItem>Close the application</ComboBoxItem>
+						<ComboBoxItem>Show completion time</ComboBoxItem>
 					</ComboBox>
 					<CheckBox Name="AudioEvents" Content="Enable sound notifications for the conversion status" Margin="2, 16, 0, 0" IsCheckedChanged="AudioEventsCheck" />
 					<CheckBox Name="OldKMCScheme" Content="Use old KMC sound scheme" Margin="2" />

--- a/OmniConverter/Forms/SettingsWindow.axaml.cs
+++ b/OmniConverter/Forms/SettingsWindow.axaml.cs
@@ -30,7 +30,7 @@ public partial class SettingsWindow : Window
             {
                 int freq = Convert.ToInt32(((ComboBoxItem)item).Content);
 
-                if (freq == Program.Settings.SampleRate)
+                if (freq == Program.Settings.Synth.SampleRate)
                 {
                     SampleRate.SelectedIndex = i;
                     break;
@@ -53,47 +53,56 @@ public partial class SettingsWindow : Window
         SelectedRenderer.SelectedIndex = ((int)Program.Settings.Renderer).LimitToRange((int)EngineID.BASS, (int)EngineID.MAX);
         AudioRendererChanged(sender, new SelectionChangedEventArgs(e.RoutedEvent, null, null));
 
-        AudioCodec.SelectedIndex = ((int)Program.Settings.AudioCodec).LimitToRange((int)AudioCodecType.PCM, (int)maxCodec);
-        AudioBitrate.Value = Program.Settings.AudioBitrate.LimitToRange(1, (int)AudioBitrate.Maximum);
+        AudioCodec.SelectedIndex = ((int)Program.Settings.Encoder.AudioCodec).LimitToRange((int)AudioCodecType.PCM, (int)maxCodec);
+        AudioBitrate.Value = Program.Settings.Encoder.AudioBitrate.LimitToRange(1, (int)AudioBitrate.Maximum);
+        
+        InterpolationSelection.SelectedIndex = ((int)Program.Settings.Synth.Interpolation)
+            .LimitToRange((int)GlobalSynthSettings.InterpolationType.None,
+                          (int)GlobalSynthSettings.InterpolationType.Max);
 
-        SincInterSelection.SelectedIndex = ((int)Program.Settings.SincInter).LimitToRange((int)SincInterType.Linear, (int)SincInterType.Max);
+        XSynth_ThreadingSelection.SelectedIndex = ((int)Program.Settings.XSynth.Threading)
+            .LimitToRange((int)XSynthSettings.ThreadingType.None, (int)XSynthSettings.ThreadingType.Max);
 
-        DisableFX.IsChecked = Program.Settings.DisableEffects;
-        NoteOff1.IsChecked = Program.Settings.NoteOff1;
-        KilledNoteFading.IsChecked = Program.Settings.KilledNoteFading;
-        AudioLimiter.IsChecked = Program.Settings.AudioLimiter;
+        BASS_MaxVoices.Value = Program.Settings.BASS.MaxVoices;
+        XSynth_MaxLayers.Value = Program.Settings.XSynth.MaxLayers;
+        BASS_DisableFX.IsChecked = Program.Settings.BASS.DisableEffects;
+        BASS_NoteOff1.IsChecked = Program.Settings.BASS.NoteOff1;
+        XSynth_UseEffects.IsChecked = Program.Settings.XSynth.UseEffects;
+        XSynth_LinearEnv.IsChecked = Program.Settings.XSynth.LinearEnvelope;
+        KilledNoteFading.IsChecked = Program.Settings.Synth.KilledNoteFading;
+        AudioLimiter.IsChecked = Program.Settings.Synth.AudioLimiter;
         AudioCodecChanged(sender, new SelectionChangedEventArgs(e.RoutedEvent, null, null));
 
-        RTSMode.IsChecked = Program.Settings.RTSMode;
-        RTSFPS.Value = (decimal)Program.Settings.RTSFPS;
-        RTSFluct.Value = (decimal)Program.Settings.RTSFluct;
+        RTSMode.IsChecked = Program.Settings.Synth.RTSMode;
+        RTSFPS.Value = (decimal)Program.Settings.Synth.RTSFPS;
+        RTSFluct.Value = (decimal)Program.Settings.Synth.RTSFluct;
         RTSModeCheck(sender, e);
 
-        FilterVelocity.IsChecked = Program.Settings.FilterVelocity;
-        VelocityLowValue.Value = Program.Settings.VelocityLow;
-        VelocityHighValue.Value = Program.Settings.VelocityHigh;
+        FilterVelocity.IsChecked = Program.Settings.Event.FilterVelocity;
+        VelocityLowValue.Value = Program.Settings.Event.VelocityLow;
+        VelocityHighValue.Value = Program.Settings.Event.VelocityHigh;
         FilterVelocityCheck(sender, e);
 
-        FilterKey.IsChecked = Program.Settings.FilterKey;
-        KeyLowValue.Value = Program.Settings.KeyLow;
-        KeyHighValue.Value = Program.Settings.KeyHigh;
+        FilterKey.IsChecked = Program.Settings.Event.FilterKey;
+        KeyLowValue.Value = Program.Settings.Event.KeyLow;
+        KeyHighValue.Value = Program.Settings.Event.KeyHigh;
         FilterKeyCheck(sender, e);
 
-        OverrideEffects.IsChecked = Program.Settings.OverrideEffects;
-        ReverbValue.Value = Program.Settings.ReverbVal;
-        ChorusValue.Value = Program.Settings.ChorusVal;
+        OverrideEffects.IsChecked = Program.Settings.Event.OverrideEffects;
+        ReverbValue.Value = Program.Settings.Event.ReverbVal;
+        ChorusValue.Value = Program.Settings.Event.ChorusVal;
         OverrideEffectsCheck(sender, e);
 
-        IgnoreProgramChanges.IsChecked = Program.Settings.IgnoreProgramChanges;
+        IgnoreProgramChanges.IsChecked = Program.Settings.Event.IgnoreProgramChanges;
 
-        MTMode.IsChecked = Program.Settings.MultiThreadedMode;
-        PerTrackMode.IsChecked = Program.Settings.PerTrackMode;
-        PerTrackFile.IsChecked = Program.Settings.PerTrackFile;
-        PerTrackStorage.IsChecked = Program.Settings.PerTrackStorage;
+        MTMode.IsChecked = Program.Settings.Render.MultiThreadedMode;
+        PerTrackMode.IsChecked = Program.Settings.Render.PerTrackMode;
+        PerTrackFile.IsChecked = Program.Settings.Render.PerTrackFile;
+        PerTrackStorage.IsChecked = Program.Settings.Render.PerTrackStorage;
 
-        NoLimitThreadsOnCPU.IsChecked = Program.Settings.ThreadsCount > Environment.ProcessorCount;   
+        NoLimitThreadsOnCPU.IsChecked = Program.Settings.Render.ThreadsCount > Environment.ProcessorCount;   
         NoLimitThreadsOnCPUCheck(sender, e);
-        MaxThreads.Value = Program.Settings.ThreadsCount.LimitToRange(1, (int)MaxThreads.Maximum);
+        MaxThreads.Value = Program.Settings.Render.ThreadsCount.LimitToRange(1, (int)MaxThreads.Maximum);
 
         if ((bool)NoLimitThreadsOnCPU.IsChecked)
             LimitThreads.IsChecked = true;
@@ -102,17 +111,17 @@ public partial class SettingsWindow : Window
 
         MaxThreadsPanel.IsEnabled = (bool)LimitThreads.IsChecked;
 
-        AutoExportToFolder.IsChecked = Program.Settings.AutoExportToFolder;
-        AutoExportFolderPath.Text = Program.Settings.AutoExportFolderPath;
+        AutoExportToFolder.IsChecked = Program.Settings.Render.AutoExportToFolder;
+        AutoExportFolderPath.Text = Program.Settings.Render.AutoExportFolderPath;
         AutoExportFolderCheck(sender, e);
 
-        AfterRenderAction.IsChecked = Program.Settings.AfterRenderAction >= 0;
-        AfterRenderSelectedAction.SelectedIndex = Program.Settings.AfterRenderAction.LimitToRange(0, AfterRenderSelectedAction.Items.Count);
+        AfterRenderAction.IsChecked = Program.Settings.Program.AfterRenderAction >= 0;
+        AfterRenderSelectedAction.SelectedIndex = Program.Settings.Program.AfterRenderAction.LimitToRange(0, AfterRenderSelectedAction.Items.Count);
         AfterRenderActionCheck(sender, e);
 
         NoFFMPEG.IsVisible = NoFFMPEGFound;
-        AudioEvents.IsChecked = Program.Settings.AudioEvents;
-        OldKMCScheme.IsChecked = Program.Settings.OldKMCScheme;
+        AudioEvents.IsChecked = Program.Settings.Program.AudioEvents;
+        OldKMCScheme.IsChecked = Program.Settings.Program.OldKMCScheme;
         AudioEventsCheck(sender, e);
     }
 
@@ -147,8 +156,8 @@ public partial class SettingsWindow : Window
 
     private void MaxVoicesChanged(object? sender, NumericUpDownValueChangedEventArgs e)
     {
-        if (MaxVoices.Value > MaxVoices.Maximum)
-            MaxVoices.Value = MaxVoices.Maximum;
+        if (BASS_MaxVoices.Value > BASS_MaxVoices.Maximum)
+            BASS_MaxVoices.Value = BASS_MaxVoices.Maximum;
     }
 
     private void AudioCodecChanged(object? sender, SelectionChangedEventArgs e)
@@ -166,7 +175,7 @@ public partial class SettingsWindow : Window
 
                 default:
                     ForceLimitAudio = false;
-                    AudioLimiter.IsChecked = Program.Settings.AudioLimiter;
+                    AudioLimiter.IsChecked = Program.Settings.Synth.AudioLimiter;
                     break;
             }
 
@@ -176,24 +185,23 @@ public partial class SettingsWindow : Window
 
     private void KhangModCheck(object? sender, RoutedEventArgs e)
     {
-        if (NoVoiceLimit.IsChecked != null)
+        if (BASS_NoVoiceLimit.IsChecked != null)
         {
-            switch ((EngineID)SelectedRenderer.SelectedIndex)
-            {
-                case EngineID.XSynth:
-                    NoVoiceLimit.Content = "Unlimited";
-                    MaxVoices.IsEnabled = !(bool)NoVoiceLimit.IsChecked;
-                    MaxVoices.Value = (bool)NoVoiceLimit.IsChecked ? 0 : Program.Settings.MaxLayers;
-                    break;
-
-                default:
-                    NoVoiceLimit.Content = "Uncap limit";
-                    MaxVoices.IsEnabled = true;
-                    MaxVoices.Maximum = (bool)NoVoiceLimit.IsChecked ? int.MaxValue : 100000;
-                    break;
-            }
-
+            BASS_MaxVoices.Maximum = (bool)BASS_NoVoiceLimit.IsChecked ? int.MaxValue : 100000;
             MaxVoicesChanged(null, new NumericUpDownValueChangedEventArgs(e.RoutedEvent, null, null));
+        }
+    }
+
+    private void UnlimitedLayersCheck(object? sender, RoutedEventArgs e)
+    {
+        if (XSynth_NoLayerLimit.IsChecked != null)
+        {
+            if ((bool)XSynth_NoLayerLimit.IsChecked)
+                XSynth_MaxLayers.Minimum = 0;
+            else
+                XSynth_MaxLayers.Minimum = 1;
+            XSynth_MaxLayers.Value = (bool)XSynth_NoLayerLimit.IsChecked ? 0 : Program.Settings.XSynth.MaxLayers;
+            XSynth_MaxLayers.IsEnabled = !(bool)XSynth_NoLayerLimit.IsChecked;
         }
     }
 
@@ -204,20 +212,20 @@ public partial class SettingsWindow : Window
             switch ((EngineID)SelectedRenderer.SelectedIndex)
             {
                 case EngineID.XSynth:
-                    NotDesignedForThis.IsVisible = true;
-                    MaxVoicesLabel.Content = "Layer count";
-                    NoVoiceLimit.IsChecked = Program.Settings.MaxLayers == 0;
-                    MaxVoices.Minimum = 0;
-                    MaxVoices.Value = Program.Settings.MaxLayers;
-                    KhangModCheck(sender, new RoutedEventArgs(e.RoutedEvent));
+                    XSynth_NoLayerLimit.IsChecked = Program.Settings.XSynth.MaxLayers == 0;
+                    XSynth_MaxLayers.Value = Program.Settings.XSynth.MaxLayers;
+                    BASSSettingsPanel.IsVisible = false;
+                    XSynthSettingsPanel.IsVisible = true;
                     break;
 
+                case EngineID.BASS:
+                    BASS_NoVoiceLimit.IsChecked = Program.Settings.BASS.MaxVoices > 100000;
+                    BASS_MaxVoices.Value = Program.Settings.BASS.MaxVoices;
+                    BASSSettingsPanel.IsVisible = true;
+                    XSynthSettingsPanel.IsVisible = false;
+                    break;
+                
                 default:
-                    NotDesignedForThis.IsVisible = false;
-                    MaxVoicesLabel.Content = "Voice limit";
-                    NoVoiceLimit.IsChecked = Program.Settings.MaxVoices > 100000;
-                    MaxVoices.Minimum = 1;
-                    MaxVoices.Value = Program.Settings.MaxVoices;
                     break;
             }
         }
@@ -227,13 +235,6 @@ public partial class SettingsWindow : Window
     {
         MessageBox.Show(this, "To use additional formats, you need ffmpeg.\n\n" +
             "Please install it on your system, or move the ffmpeg binary to the same folder as the converter.",
-            "OmniConverter - Warning", MsBox.Avalonia.Enums.ButtonEnum.Ok, MsBox.Avalonia.Enums.Icon.Warning);
-    }
-
-    private void NotDesignedForThisWarning(object? sender, Avalonia.Input.PointerPressedEventArgs e)
-    {
-        MessageBox.Show(this, "This converter is primarily designed around BASSMIDI.\n\n" +
-            "Some features might not be available with other audio engines.",
             "OmniConverter - Warning", MsBox.Avalonia.Enums.ButtonEnum.Ok, MsBox.Avalonia.Enums.Icon.Warning);
     }
 
@@ -336,104 +337,94 @@ public partial class SettingsWindow : Window
 
         object? item = SampleRate.Items[SampleRate.SelectedIndex];
         if (item != null)
-            Program.Settings.SampleRate = Convert.ToInt32(((ComboBoxItem)item).Content);
+            Program.Settings.Synth.SampleRate = Convert.ToInt32(((ComboBoxItem)item).Content);
 
-        if (MaxVoices.Value != null)
-        {
-            if (SelectedRenderer != null)
-            {
-                switch ((EngineID)SelectedRenderer.SelectedIndex)
-                {
-                    case EngineID.XSynth:
-                        Program.Settings.MaxLayers = (ulong)MaxVoices.Value;
-                        break;
-
-                    default:
-                        Program.Settings.MaxVoices = (int)MaxVoices.Value;
-                        break;
-                }
-            }
-        }
+        if (BASS_MaxVoices.Value != null)
+            Program.Settings.BASS.MaxVoices = (int)BASS_MaxVoices.Value;
+        if (XSynth_MaxLayers.Value != null)
+            Program.Settings.XSynth.MaxLayers = (ulong)XSynth_MaxLayers.Value;
 
         Program.Settings.Renderer = (EngineID)SelectedRenderer.SelectedIndex;
-        Program.Settings.SincInter = (SincInterType)SincInterSelection.SelectedIndex;
 
-        Program.Settings.AudioCodec = (AudioCodecType)AudioCodec.SelectedIndex;
+        Program.Settings.Synth.Interpolation = (GlobalSynthSettings.InterpolationType)InterpolationSelection.SelectedIndex;
+        Program.Settings.XSynth.Threading = (XSynthSettings.ThreadingType)XSynth_ThreadingSelection.SelectedIndex;
+
+        Program.Settings.Encoder.AudioCodec = (AudioCodecType)AudioCodec.SelectedIndex;
         if (AudioBitrate.Value != null)
-            Program.Settings.AudioBitrate = (int)AudioBitrate.Value;
+            Program.Settings.Encoder.AudioBitrate = (int)AudioBitrate.Value;
 
-        if (DisableFX.IsChecked != null)
-            Program.Settings.DisableEffects = (bool)DisableFX.IsChecked;
-        if (NoteOff1.IsChecked != null)
-            Program.Settings.NoteOff1 = (bool)NoteOff1.IsChecked;
+        if (BASS_DisableFX.IsChecked != null)
+            Program.Settings.BASS.DisableEffects = (bool)BASS_DisableFX.IsChecked;
+        if (BASS_NoteOff1.IsChecked != null)
+            Program.Settings.BASS.NoteOff1 = (bool)BASS_NoteOff1.IsChecked;
         if (KilledNoteFading.IsChecked != null)
-            Program.Settings.KilledNoteFading = (bool)KilledNoteFading.IsChecked;
+            Program.Settings.Synth.KilledNoteFading = (bool)KilledNoteFading.IsChecked;
 
         if (AudioLimiter.IsChecked != null && !ForceLimitAudio)
-            Program.Settings.AudioLimiter = (bool)AudioLimiter.IsChecked;
+            Program.Settings.Synth.AudioLimiter = (bool)AudioLimiter.IsChecked;
 
         if (RTSMode.IsChecked != null)
-            Program.Settings.RTSMode = (bool)RTSMode.IsChecked;
+            Program.Settings.Synth.RTSMode = (bool)RTSMode.IsChecked;
         if (RTSFPS.Value != null)
-            Program.Settings.RTSFPS = (double)RTSFPS.Value;
+            Program.Settings.Synth.RTSFPS = (double)RTSFPS.Value;
         if (RTSFluct.Value != null)
-            Program.Settings.RTSFluct = (double)RTSFluct.Value;
+            Program.Settings.Synth.RTSFluct = (double)RTSFluct.Value;
 
         if (FilterVelocity.IsChecked != null)
-            Program.Settings.FilterVelocity = (bool)FilterVelocity.IsChecked;
+            Program.Settings.Event.FilterVelocity = (bool)FilterVelocity.IsChecked;
         if (VelocityLowValue.Value != null)
-            Program.Settings.VelocityLow = (int)VelocityLowValue.Value;
+            Program.Settings.Event.VelocityLow = (int)VelocityLowValue.Value;
         if (VelocityHighValue.Value != null)
-            Program.Settings.VelocityHigh = (int)VelocityHighValue.Value;
+            Program.Settings.Event.VelocityHigh = (int)VelocityHighValue.Value;
         
         if (FilterKey.IsChecked != null)
-            Program.Settings.FilterKey = (bool)FilterKey.IsChecked;
+            Program.Settings.Event.FilterKey = (bool)FilterKey.IsChecked;
         if (KeyLowValue.Value != null)
-            Program.Settings.KeyLow = (int)KeyLowValue.Value;
+            Program.Settings.Event.KeyLow = (int)KeyLowValue.Value;
         if (KeyHighValue.Value != null)
-            Program.Settings.KeyHigh = (int)KeyHighValue.Value;
+            Program.Settings.Event.KeyHigh = (int)KeyHighValue.Value;
 
         if (OverrideEffects.IsChecked != null)
-            Program.Settings.OverrideEffects = (bool)OverrideEffects.IsChecked;
+            Program.Settings.Event.OverrideEffects = (bool)OverrideEffects.IsChecked;
         if (ReverbValue.Value != null)
-            Program.Settings.ReverbVal = (short)ReverbValue.Value;
+            Program.Settings.Event.ReverbVal = (short)ReverbValue.Value;
         if (ChorusValue.Value != null)
-            Program.Settings.ChorusVal = (short)ChorusValue.Value;
+            Program.Settings.Event.ChorusVal = (short)ChorusValue.Value;
 
         if (IgnoreProgramChanges.IsChecked != null)
-            Program.Settings.IgnoreProgramChanges = (bool)IgnoreProgramChanges.IsChecked;
+            Program.Settings.Event.IgnoreProgramChanges = (bool)IgnoreProgramChanges.IsChecked;
 
         if (MTMode.IsChecked != null)
-            Program.Settings.MultiThreadedMode = (bool)MTMode.IsChecked;
+            Program.Settings.Render.MultiThreadedMode = (bool)MTMode.IsChecked;
         if (PerTrackMode.IsChecked != null)
-            Program.Settings.PerTrackMode = (bool)PerTrackMode.IsChecked;
+            Program.Settings.Render.PerTrackMode = (bool)PerTrackMode.IsChecked;
         if (PerTrackFile.IsChecked != null)
-            Program.Settings.PerTrackFile = (bool)PerTrackFile.IsChecked;
+            Program.Settings.Render.PerTrackFile = (bool)PerTrackFile.IsChecked;
         if (PerTrackStorage.IsChecked != null)
-            Program.Settings.PerTrackStorage = (bool)PerTrackStorage.IsChecked;
+            Program.Settings.Render.PerTrackStorage = (bool)PerTrackStorage.IsChecked;
 
         if (LimitThreads.IsChecked != null)
         {
             if ((bool)LimitThreads.IsChecked && MaxThreads.Value != null)
-                Program.Settings.ThreadsCount = (int)MaxThreads.Value;
-            else Program.Settings.ThreadsCount = Environment.ProcessorCount;
+                Program.Settings.Render.ThreadsCount = (int)MaxThreads.Value;
+            else Program.Settings.Render.ThreadsCount = Environment.ProcessorCount;
         }
 
         if (AutoExportToFolder.IsChecked != null)
-            Program.Settings.AutoExportToFolder = (bool)AutoExportToFolder.IsChecked;
+            Program.Settings.Render.AutoExportToFolder = (bool)AutoExportToFolder.IsChecked;
 
         if (AfterRenderAction.IsChecked != null && (bool)AfterRenderAction.IsChecked)
-            Program.Settings.AfterRenderAction = AfterRenderSelectedAction.SelectedIndex;
-        else Program.Settings.AfterRenderAction = -1;
+            Program.Settings.Program.AfterRenderAction = AfterRenderSelectedAction.SelectedIndex;
+        else Program.Settings.Program.AfterRenderAction = -1;
 
         if (AudioEvents.IsChecked != null)
-            Program.Settings.AudioEvents = (bool)AudioEvents.IsChecked;
+            Program.Settings.Program.AudioEvents = (bool)AudioEvents.IsChecked;
 
         if (OldKMCScheme.IsChecked != null)
-            Program.Settings.OldKMCScheme = (bool)OldKMCScheme.IsChecked;
+            Program.Settings.Program.OldKMCScheme = (bool)OldKMCScheme.IsChecked;
 
         var newExportPath = AutoExportFolderPath.Text;
-        if (newExportPath != null && !newExportPath.Equals(Program.Settings.AutoExportFolderPath))
+        if (newExportPath != null && !newExportPath.Equals(Program.Settings.Render.AutoExportFolderPath))
         {
             if (!Directory.Exists(newExportPath))
             {
@@ -468,7 +459,7 @@ public partial class SettingsWindow : Window
                         File.Delete(testFile);
                     }
 
-                    if (success) Program.Settings.AutoExportFolderPath = newExportPath;
+                    if (success) Program.Settings.Render.AutoExportFolderPath = newExportPath;
                 }
             }
         }


### PR DESCRIPTION
First of all sorry for making such a big PR lol. So I decided to take some time and make the settings in OM a bit more modular and organized by splitting options into certain groups. 
The file currently looks something like this:

<details>
<summary>settings.json</summary>

```json
{
  "Renderer": 1,
  "Synth": {
    "Volume": 1.0,
    "SampleRate": 48000,
    "Interpolation": 0,
    "KilledNoteFading": false,
    "AudioLimiter": true,
    "RTSMode": false,
    "RTSFPS": 90.0,
    "RTSFluct": 75.0
  },
  "BASS": {
    "MaxVoices": 1000,
    "DisableEffects": true,
    "NoteOff1": false
  },
  "XSynth": {
    "MaxLayers": 32,
    "UseEffects": true,
    "Threading": 2,
    "LinearEnvelope": false
  },
  "Encoder": {
    "AudioCodec": 0,
    "AudioBitrate": 256
  },
  "Event": {
    "FilterVelocity": false,
    "VelocityLow": 1,
    "VelocityHigh": 1,
    "FilterKey": false,
    "KeyLow": 0,
    "KeyHigh": 127,
    "OverrideEffects": false,
    "ReverbVal": 64,
    "ChorusVal": 64,
    "IgnoreProgramChanges": false
  },
  "Render": {
    "MultiThreadedMode": true,
    "ThreadsCount": 8,
    "PerTrackMode": false,
    "PerTrackFile": false,
    "PerTrackStorage": false,
    "AutoExportToFolder": false,
    "AutoExportFolderPath": ""
  },
  "Program": {
    "AutoSaveState": false,
    "RichPresence": true,
    "AutoUpdateCheck": false,
    "UpdateBranch": 1,
    "AfterRenderAction": -1,
    "AudioEvents": true,
    "OldKMCScheme": false
  },
  "LastMIDIFolder": "",
  "LastSoundFontFolder": "",
  "LastExportFolder": "",
  "SoundFonts": [
    {
      "Path": "something.sf2",
      "SourcePreset": -1,
      "SourceBank": -1,
      "DestinationPreset": -1,
      "DestinationBank": 0,
      "DestinationBankLSB": 0,
      "Enabled": true,
      "XGMode": false
    }
  ]
}
```
</details>

I also made a few changes to the organization of the settings window, including separate settings for each synthesizer. You can see how it looks in this video:

<details>
<summary>Settings window</summary>

https://github.com/user-attachments/assets/2fc6deda-65da-4330-9d57-9f321658a0c4

</details>

## A few things to note

- I didn't test this extensively. I did do some test renders with some major settings, I did not test all of them. They *should* work because I didn't make any fundamental changes except for their location in the `Settings` class, but I thought I should let you know anyway
- Settings from the old format/file are simply discarded. I did not make any migration code to keep the settings from the old format. Let me know if you want me to do that.
- I had plans to divide the settings window tabs into separate `.axaml` files to make their  `.cs` files easier to manage, but I have actually no idea how to do that. So if you know how I would highly recommend it.

## Other things

- I updated the repo link in the program
- I would recommend using [CSharpier](https://csharpier.com/) to format the code because there are a lot of areas where it is very hard to read it as stuff gets out of screen or is weirdly formatted. I was about to include it in this PR but it would create many more changes and it would be hard for you to read the actual settings changes I made. It is very simple to set up, you just do `dotnet tool install csharpier` and then `dotnet csharpier .` and it will format the whole project so it's more readable.


If there are any changes you want me to make let me know and I'll do then asap.